### PR TITLE
各種リンクといいねボタン追加

### DIFF
--- a/front/topicslab/src/App.vue
+++ b/front/topicslab/src/App.vue
@@ -2,7 +2,7 @@
   <div id="nav">
     <router-link to="/">Home</router-link> |
     <template v-if="authenticated">
-      <a>mypage</a>
+      <router-link to="/mypage">mypage</router-link>
     </template>
     <template v-else>
       <router-link to="/login">login</router-link>

--- a/front/topicslab/src/components/Comments.vue
+++ b/front/topicslab/src/components/Comments.vue
@@ -2,10 +2,13 @@
   <div>
     <Fieldset v-for="comment in comments" :key="comment.id">
       <template #legend>
-        <span>{{comment.user.name}}</span>
+        <span>
+          <router-link :to="`/user/${comment.user.id}`">{{comment.user.name}}</router-link>
+        </span>
       </template>
       <div class="comment-text">
         {{comment.body}}
+        <Button label="いいね" />
       </div>
     </Fieldset>
   </div>

--- a/front/topicslab/src/views/Register.vue
+++ b/front/topicslab/src/views/Register.vue
@@ -61,6 +61,7 @@ export default {
             .then((res) => {
               if (res.status === 201) {
                 alert('ユーザー登録成功')
+                this.$router.push('/login')
               } else {
                 this.message = 'ユーザー登録に失敗しました。'
               }

--- a/front/topicslab/src/views/Topic.vue
+++ b/front/topicslab/src/views/Topic.vue
@@ -7,6 +7,8 @@
       <template #content>
         <div class="body-text">
           {{topic.body}}
+          <br>
+          <Button label="いいね" />
         </div>
       </template>
       <template #footer>
@@ -40,6 +42,10 @@ export default {
     }
   },
   mounted () {
+    if (localStorage.getItem('authenticated') !== 'true') {
+      this.$router.push('/login')
+      return
+    }
     this.id = this.$route.params.id
     if (!this.id) {
       alert('不正なIDです。')

--- a/front/topicslab/src/views/User.vue
+++ b/front/topicslab/src/views/User.vue
@@ -21,7 +21,7 @@ export default {
   },
   mounted () {
     if (localStorage.getItem('authenticated') !== 'true') {
-      this.$router.push('login')
+      this.$router.push('/login')
       return
     }
 


### PR DESCRIPTION
## 報告内容
- 指示書の8,9,10,14,15,17,18の項目を追加しました(2021/9/24)
- トピックとユーザがログインされていない時のログイン画面への自動遷移
- マイページのリンク追加
- いいねボタン追加
- ユーザ名からの遷移
- 登録完了アラートから画面遷移